### PR TITLE
fix: variable access issues

### DIFF
--- a/tagger/interrogator.py
+++ b/tagger/interrogator.py
@@ -445,6 +445,8 @@ class WaifuDiffusionInterrogator(Interrogator):
         }
         mpath = Path(mdir, 'model.json')
 
+        data = [download_model]
+
         if not os.path.exists(mdir):
             os.mkdir(mdir)
 

--- a/tagger/uiset.py
+++ b/tagger/uiset.py
@@ -115,7 +115,7 @@ class IOData:
             output_dir = base_dir
 
             cls.output_root = Path(output_dir)
-        elif not cls.output_root or cls.output_root == Path(cls.base_dir):
+        elif not cls.output_root or (cls.base_dir and cls.output_root == Path(cls.base_dir)):
             cls.output_root = Path(base_dir)
 
         cls.base_dir_last = Path(base_dir).parts[-1]


### PR DESCRIPTION
This fixes two errors:

1. `UnboundLocalError: local variable 'data' referenced before assignment` when model.json is missing (after a fresh install).

2. `TypeError: expected str, bytes or os.PathLike object, not NoneType` when setting input directory in the UI.
Reproduction steps:
   ```
   1. After SD startup, go to the Tagger tab
   2. Fill in `Output directory`
   3. Check `Unload model after running` (maybe other operations also have the same effect, but I didn't test it)
   4. Fill in `Input directory` and click somewhere else
   ```