### PR TITLE
Manually download models

### DIFF
--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -60,7 +60,6 @@ interrogators: Dict[str, Interrogator] = {
 }
 
 
-
 def refresh_interrogators() -> List[str]:
     """Refreshes the interrogators list"""
     # load deepdanbooru project
@@ -111,12 +110,13 @@ def refresh_interrogators() -> List[str]:
         if path.name not in interrogators.keys():
             if path.name == 'wd-v1-4-convnextv2-tagger-v2':
                 interrogators[path.name] = WaifuDiffusionInterrogator(
-                    path.name, repo_id='SmilingWolf/SW-CV-ModelZoo', is_hf=False
+                    path.name, 
+                    repo_id='SmilingWolf/SW-CV-ModelZoo', 
+                    is_hf=False
                 )
             elif path.name == 'Z3D-E621-Convnext':
                 interrogators[path.name] = WaifuDiffusionInterrogator(
-                    'Z3D-E621-Convnext', is_hf=False
-                )
+                    'Z3D-E621-Convnext', is_hf=False)
             else:
                 try:
                   interrogators[path.name] = WaifuDiffusionInterrogator(

--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -17,44 +17,48 @@ from tagger.interrogator import WaifuDiffusionInterrogator  # pylint: disable=E0
 preset = Preset(Path(scripts.basedir(), 'presets'))
 
 interrogators: Dict[str, Interrogator] = {
-    "wd14-vit.v1": WaifuDiffusionInterrogator(
-        "WD14 ViT v1", repo_id="SmilingWolf/wd-v1-4-vit-tagger"
+    'wd14-vit.v1': WaifuDiffusionInterrogator(
+        'WD14 ViT v1',
+        repo_id='SmilingWolf/wd-v1-4-vit-tagger'
     ),
-    "wd14-vit.v2": WaifuDiffusionInterrogator(
-        "WD14 ViT v2",
-        repo_id="SmilingWolf/wd-v1-4-vit-tagger-v2",
+    'wd14-vit.v2': WaifuDiffusionInterrogator(
+        'WD14 ViT v2',
+        repo_id='SmilingWolf/wd-v1-4-vit-tagger-v2',
     ),
-    "wd14-convnext.v1": WaifuDiffusionInterrogator(
-        "WD14 ConvNeXT v1", repo_id="SmilingWolf/wd-v1-4-convnext-tagger"
+    'wd14-convnext.v1': WaifuDiffusionInterrogator(
+        'WD14 ConvNeXT v1',
+        repo_id='SmilingWolf/wd-v1-4-convnext-tagger'
     ),
-    "wd14-convnext.v2": WaifuDiffusionInterrogator(
-        "WD14 ConvNeXT v2",
-        repo_id="SmilingWolf/wd-v1-4-convnext-tagger-v2",
+    'wd14-convnext.v2': WaifuDiffusionInterrogator(
+        'WD14 ConvNeXT v2',
+        repo_id='SmilingWolf/wd-v1-4-convnext-tagger-v2',
     ),
-    "wd14-convnextv2.v1": WaifuDiffusionInterrogator(
-        "WD14 ConvNeXTV2 v1",
+    'wd14-convnextv2.v1': WaifuDiffusionInterrogator(
+        'WD14 ConvNeXTV2 v1',
         # the name is misleading, but it's v1
-        repo_id="SmilingWolf/wd-v1-4-convnextv2-tagger-v2",
+        repo_id='SmilingWolf/wd-v1-4-convnextv2-tagger-v2',
     ),
-    "wd14-swinv2-v1": WaifuDiffusionInterrogator(
-        "WD14 SwinV2 v1",
+    'wd14-swinv2-v1': WaifuDiffusionInterrogator(
+        'WD14 SwinV2 v1',
         # again misleading name
-        repo_id="SmilingWolf/wd-v1-4-swinv2-tagger-v2",
+        repo_id='SmilingWolf/wd-v1-4-swinv2-tagger-v2',
     ),
-    "wd-v1-4-moat-tagger.v2": WaifuDiffusionInterrogator(
-        "WD14 moat tagger v2", repo_id="SmilingWolf/wd-v1-4-moat-tagger-v2"
+    'wd-v1-4-moat-tagger.v2': WaifuDiffusionInterrogator(
+        'WD14 moat tagger v2',
+        repo_id='SmilingWolf/wd-v1-4-moat-tagger-v2'
     ),
-    "mld-caformer.dec-5-97527": MLDanbooruInterrogator(
-        "ML-Danbooru Caformer dec-5-97527",
-        repo_id="deepghs/ml-danbooru-onnx",
-        model_path="ml_caformer_m36_dec-5-97527.onnx",
+    'mld-caformer.dec-5-97527': MLDanbooruInterrogator(
+        'ML-Danbooru Caformer dec-5-97527',
+        repo_id='deepghs/ml-danbooru-onnx',
+        model_path='ml_caformer_m36_dec-5-97527.onnx'
     ),
-    "mld-tresnetd.6-30000": MLDanbooruInterrogator(
-        "ML-Danbooru TResNet-D 6-30000",
-        repo_id="deepghs/ml-danbooru-onnx",
-        model_path="TResnet-D-FLq_ema_6-30000.onnx",
+    'mld-tresnetd.6-30000': MLDanbooruInterrogator(
+        'ML-Danbooru TResNet-D 6-30000',
+        repo_id='deepghs/ml-danbooru-onnx',
+        model_path='TResnet-D-FLq_ema_6-30000.onnx'
     ),
 }
+
 
 
 def refresh_interrogators() -> List[str]:

--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -17,46 +17,43 @@ from tagger.interrogator import WaifuDiffusionInterrogator  # pylint: disable=E0
 preset = Preset(Path(scripts.basedir(), 'presets'))
 
 interrogators: Dict[str, Interrogator] = {
-    'wd14-vit.v1': WaifuDiffusionInterrogator(
-        'WD14 ViT v1',
-        repo_id='SmilingWolf/wd-v1-4-vit-tagger'
-    ),
-    'wd14-vit.v2': WaifuDiffusionInterrogator(
-        'WD14 ViT v2',
-        repo_id='SmilingWolf/wd-v1-4-vit-tagger-v2',
-    ),
-    'wd14-convnext.v1': WaifuDiffusionInterrogator(
-        'WD14 ConvNeXT v1',
-        repo_id='SmilingWolf/wd-v1-4-convnext-tagger'
-    ),
-    'wd14-convnext.v2': WaifuDiffusionInterrogator(
-        'WD14 ConvNeXT v2',
-        repo_id='SmilingWolf/wd-v1-4-convnext-tagger-v2',
-    ),
-    'wd14-convnextv2.v1': WaifuDiffusionInterrogator(
-        'WD14 ConvNeXTV2 v1',
-        # the name is misleading, but it's v1
-        repo_id='SmilingWolf/wd-v1-4-convnextv2-tagger-v2',
-    ),
-    'wd14-swinv2-v1': WaifuDiffusionInterrogator(
-        'WD14 SwinV2 v1',
-        # again misleading name
-        repo_id='SmilingWolf/wd-v1-4-swinv2-tagger-v2',
-    ),
-    'wd-v1-4-moat-tagger.v2': WaifuDiffusionInterrogator(
-        'WD14 moat tagger v2',
-        repo_id='SmilingWolf/wd-v1-4-moat-tagger-v2'
-    ),
-    'mld-caformer.dec-5-97527': MLDanbooruInterrogator(
-        'ML-Danbooru Caformer dec-5-97527',
-        repo_id='deepghs/ml-danbooru-onnx',
-        model_path='ml_caformer_m36_dec-5-97527.onnx'
-    ),
-    'mld-tresnetd.6-30000': MLDanbooruInterrogator(
-        'ML-Danbooru TResNet-D 6-30000',
-        repo_id='deepghs/ml-danbooru-onnx',
-        model_path='TResnet-D-FLq_ema_6-30000.onnx'
-    ),
+    # "wd14-vit.v1": WaifuDiffusionInterrogator(
+    #     "WD14 ViT v1", repo_id="SmilingWolf/wd-v1-4-vit-tagger"
+    # ),
+    # "wd14-vit.v2": WaifuDiffusionInterrogator(
+    #     "WD14 ViT v2",
+    #     repo_id="SmilingWolf/wd-v1-4-vit-tagger-v2",
+    # ),
+    # "wd14-convnext.v1": WaifuDiffusionInterrogator(
+    #     "WD14 ConvNeXT v1", repo_id="SmilingWolf/wd-v1-4-convnext-tagger"
+    # ),
+    # "wd14-convnext.v2": WaifuDiffusionInterrogator(
+    #     "WD14 ConvNeXT v2",
+    #     repo_id="SmilingWolf/wd-v1-4-convnext-tagger-v2",
+    # ),
+    # "wd14-convnextv2.v1": WaifuDiffusionInterrogator(
+    #     "WD14 ConvNeXTV2 v1",
+    #     # the name is misleading, but it's v1
+    #     repo_id="SmilingWolf/wd-v1-4-convnextv2-tagger-v2",
+    # ),
+    # "wd14-swinv2-v1": WaifuDiffusionInterrogator(
+    #     "WD14 SwinV2 v1",
+    #     # again misleading name
+    #     repo_id="SmilingWolf/wd-v1-4-swinv2-tagger-v2",
+    # ),
+    # "wd-v1-4-moat-tagger.v2": WaifuDiffusionInterrogator(
+    #     "WD14 moat tagger v2", repo_id="SmilingWolf/wd-v1-4-moat-tagger-v2"
+    # ),
+    # "mld-caformer.dec-5-97527": MLDanbooruInterrogator(
+    #     "ML-Danbooru Caformer dec-5-97527",
+    #     repo_id="deepghs/ml-danbooru-onnx",
+    #     model_path="ml_caformer_m36_dec-5-97527.onnx",
+    # ),
+    # "mld-tresnetd.6-30000": MLDanbooruInterrogator(
+    #     "ML-Danbooru TResNet-D 6-30000",
+    #     repo_id="deepghs/ml-danbooru-onnx",
+    #     model_path="TResnet-D-FLq_ema_6-30000.onnx",
+    # ),
 }
 
 
@@ -107,19 +104,30 @@ def refresh_interrogators() -> List[str]:
         csv.sort(key=tag_select_csvs_up_front)
         tags_path = Path(path, csv[0])
 
-        if path.name not in interrogators:
-            if path.name == 'wd-v1-4-convnextv2-tagger-v2':
-                interrogators[path.name] = WaifuDiffusionInterrogator(
-                    path.name,
-                    repo_id='SmilingWolf/SW-CV-ModelZoo',
-                    is_hf=False
+        if path.name not in interrogators.keys():
+            # if path.name == "wd-v1-4-convnextv2-tagger-v2":
+            #     interrogators[path.name] = WaifuDiffusionInterrogator(
+            #         path.name, repo_id="SmilingWolf/SW-CV-ModelZoo", is_hf=False
+            #     )
+            # elif path.name == "Z3D-E621-Convnext":
+            #     interrogators[path.name] = WaifuDiffusionInterrogator(
+            #         "Z3D-E621-Convnext", is_hf=False
+            #     )
+            # else:
+            #     raise NotImplementedError(
+            #         f"Add {path.name} resolution similar to above here"
+            #     )
+            try:
+              interrogators[path.name] = WaifuDiffusionInterrogator(
+                name=path.name,
+                model_path=str(local_path),
+                tags_path=str(tags_path),
+                is_hf=False,
+              )
+            except:
+                raise NotImplementedError(
+                    f"Add {path.name} resolution similar to above here"
                 )
-            elif path.name == 'Z3D-E621-Convnext':
-                interrogators[path.name] = WaifuDiffusionInterrogator(
-                    'Z3D-E621-Convnext', is_hf=False)
-            else:
-                raise NotImplementedError(f"Add {path.name} resolution similar"
-                                          "to above here")
 
         interrogators[path.name].local_model = str(local_path)
         interrogators[path.name].local_tags = str(tags_path)

--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -110,8 +110,8 @@ def refresh_interrogators() -> List[str]:
         if path.name not in interrogators.keys():
             if path.name == 'wd-v1-4-convnextv2-tagger-v2':
                 interrogators[path.name] = WaifuDiffusionInterrogator(
-                    path.name, 
-                    repo_id='SmilingWolf/SW-CV-ModelZoo', 
+                    path.name,
+                    repo_id='SmilingWolf/SW-CV-ModelZoo',
                     is_hf=False
                 )
             elif path.name == 'Z3D-E621-Convnext':

--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -109,13 +109,13 @@ def refresh_interrogators() -> List[str]:
         tags_path = Path(path, csv[0])
 
         if path.name not in interrogators.keys():
-            if path.name == "wd-v1-4-convnextv2-tagger-v2":
+            if path.name == 'wd-v1-4-convnextv2-tagger-v2':
                 interrogators[path.name] = WaifuDiffusionInterrogator(
-                    path.name, repo_id="SmilingWolf/SW-CV-ModelZoo", is_hf=False
+                    path.name, repo_id='SmilingWolf/SW-CV-ModelZoo', is_hf=False
                 )
-            elif path.name == "Z3D-E621-Convnext":
+            elif path.name == 'Z3D-E621-Convnext':
                 interrogators[path.name] = WaifuDiffusionInterrogator(
-                    "Z3D-E621-Convnext", is_hf=False
+                    'Z3D-E621-Convnext', is_hf=False
                 )
             else:
                 try:

--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -17,43 +17,43 @@ from tagger.interrogator import WaifuDiffusionInterrogator  # pylint: disable=E0
 preset = Preset(Path(scripts.basedir(), 'presets'))
 
 interrogators: Dict[str, Interrogator] = {
-    # "wd14-vit.v1": WaifuDiffusionInterrogator(
-    #     "WD14 ViT v1", repo_id="SmilingWolf/wd-v1-4-vit-tagger"
-    # ),
-    # "wd14-vit.v2": WaifuDiffusionInterrogator(
-    #     "WD14 ViT v2",
-    #     repo_id="SmilingWolf/wd-v1-4-vit-tagger-v2",
-    # ),
-    # "wd14-convnext.v1": WaifuDiffusionInterrogator(
-    #     "WD14 ConvNeXT v1", repo_id="SmilingWolf/wd-v1-4-convnext-tagger"
-    # ),
-    # "wd14-convnext.v2": WaifuDiffusionInterrogator(
-    #     "WD14 ConvNeXT v2",
-    #     repo_id="SmilingWolf/wd-v1-4-convnext-tagger-v2",
-    # ),
-    # "wd14-convnextv2.v1": WaifuDiffusionInterrogator(
-    #     "WD14 ConvNeXTV2 v1",
-    #     # the name is misleading, but it's v1
-    #     repo_id="SmilingWolf/wd-v1-4-convnextv2-tagger-v2",
-    # ),
-    # "wd14-swinv2-v1": WaifuDiffusionInterrogator(
-    #     "WD14 SwinV2 v1",
-    #     # again misleading name
-    #     repo_id="SmilingWolf/wd-v1-4-swinv2-tagger-v2",
-    # ),
-    # "wd-v1-4-moat-tagger.v2": WaifuDiffusionInterrogator(
-    #     "WD14 moat tagger v2", repo_id="SmilingWolf/wd-v1-4-moat-tagger-v2"
-    # ),
-    # "mld-caformer.dec-5-97527": MLDanbooruInterrogator(
-    #     "ML-Danbooru Caformer dec-5-97527",
-    #     repo_id="deepghs/ml-danbooru-onnx",
-    #     model_path="ml_caformer_m36_dec-5-97527.onnx",
-    # ),
-    # "mld-tresnetd.6-30000": MLDanbooruInterrogator(
-    #     "ML-Danbooru TResNet-D 6-30000",
-    #     repo_id="deepghs/ml-danbooru-onnx",
-    #     model_path="TResnet-D-FLq_ema_6-30000.onnx",
-    # ),
+    "wd14-vit.v1": WaifuDiffusionInterrogator(
+        "WD14 ViT v1", repo_id="SmilingWolf/wd-v1-4-vit-tagger"
+    ),
+    "wd14-vit.v2": WaifuDiffusionInterrogator(
+        "WD14 ViT v2",
+        repo_id="SmilingWolf/wd-v1-4-vit-tagger-v2",
+    ),
+    "wd14-convnext.v1": WaifuDiffusionInterrogator(
+        "WD14 ConvNeXT v1", repo_id="SmilingWolf/wd-v1-4-convnext-tagger"
+    ),
+    "wd14-convnext.v2": WaifuDiffusionInterrogator(
+        "WD14 ConvNeXT v2",
+        repo_id="SmilingWolf/wd-v1-4-convnext-tagger-v2",
+    ),
+    "wd14-convnextv2.v1": WaifuDiffusionInterrogator(
+        "WD14 ConvNeXTV2 v1",
+        # the name is misleading, but it's v1
+        repo_id="SmilingWolf/wd-v1-4-convnextv2-tagger-v2",
+    ),
+    "wd14-swinv2-v1": WaifuDiffusionInterrogator(
+        "WD14 SwinV2 v1",
+        # again misleading name
+        repo_id="SmilingWolf/wd-v1-4-swinv2-tagger-v2",
+    ),
+    "wd-v1-4-moat-tagger.v2": WaifuDiffusionInterrogator(
+        "WD14 moat tagger v2", repo_id="SmilingWolf/wd-v1-4-moat-tagger-v2"
+    ),
+    "mld-caformer.dec-5-97527": MLDanbooruInterrogator(
+        "ML-Danbooru Caformer dec-5-97527",
+        repo_id="deepghs/ml-danbooru-onnx",
+        model_path="ml_caformer_m36_dec-5-97527.onnx",
+    ),
+    "mld-tresnetd.6-30000": MLDanbooruInterrogator(
+        "ML-Danbooru TResNet-D 6-30000",
+        repo_id="deepghs/ml-danbooru-onnx",
+        model_path="TResnet-D-FLq_ema_6-30000.onnx",
+    ),
 }
 
 
@@ -105,29 +105,26 @@ def refresh_interrogators() -> List[str]:
         tags_path = Path(path, csv[0])
 
         if path.name not in interrogators.keys():
-            # if path.name == "wd-v1-4-convnextv2-tagger-v2":
-            #     interrogators[path.name] = WaifuDiffusionInterrogator(
-            #         path.name, repo_id="SmilingWolf/SW-CV-ModelZoo", is_hf=False
-            #     )
-            # elif path.name == "Z3D-E621-Convnext":
-            #     interrogators[path.name] = WaifuDiffusionInterrogator(
-            #         "Z3D-E621-Convnext", is_hf=False
-            #     )
-            # else:
-            #     raise NotImplementedError(
-            #         f"Add {path.name} resolution similar to above here"
-            #     )
-            try:
-              interrogators[path.name] = WaifuDiffusionInterrogator(
-                name=path.name,
-                model_path=str(local_path),
-                tags_path=str(tags_path),
-                is_hf=False,
-              )
-            except:
-                raise NotImplementedError(
-                    f"Add {path.name} resolution similar to above here"
+            if path.name == "wd-v1-4-convnextv2-tagger-v2":
+                interrogators[path.name] = WaifuDiffusionInterrogator(
+                    path.name, repo_id="SmilingWolf/SW-CV-ModelZoo", is_hf=False
                 )
+            elif path.name == "Z3D-E621-Convnext":
+                interrogators[path.name] = WaifuDiffusionInterrogator(
+                    "Z3D-E621-Convnext", is_hf=False
+                )
+            else:
+                try:
+                  interrogators[path.name] = WaifuDiffusionInterrogator(
+                    name=path.name,
+                    model_path=str(local_path),
+                    tags_path=str(tags_path),
+                    is_hf=False,
+                  )
+                except:
+                    raise NotImplementedError(
+                        f"Add {path.name} resolution similar to above here"
+                    )
 
         interrogators[path.name].local_model = str(local_path)
         interrogators[path.name].local_tags = str(tags_path)


### PR DESCRIPTION
Based on this issue #26, the main problem of China users is the inaccess of hugging face with proxy, so just manually download these models from [https://huggingface.co/SmilingWolf](https://huggingface.co/SmilingWolf) is possible. However after manually downloading and appropriately folder placing, it is troublesome to rename the name of folders, and it is also regretfully incompatible with other models instead of  [https://huggingface.co/SmilingWolf](https://huggingface.co/SmilingWolf) #86. So it may be resolutable if modify several Interrogator loading codes in `utils.py`, to just load using path name regardless of seriously same name like 'wd14-vit.v2' etc.